### PR TITLE
added option to change bounds on the HRF parameters as n * SD

### DIFF
--- a/code/models/@mtSinai/mtSinai.m
+++ b/code/models/@mtSinai/mtSinai.m
@@ -110,6 +110,7 @@ classdef mtSinai < handle
         % The lower and upper bounds for the model
         lb
         ub
+        paraSD
         
         % A vector, equal in length to the number of parameters, that
         % specifies the smallest step size that fmincon will take for each
@@ -143,6 +144,7 @@ classdef mtSinai < handle
             p.addParameter('avgAcqIdx',{},@iscell);  
             p.addParameter('polyDeg',[],@isnumeric);
             p.addParameter('typicalGain',1,@isscalar);
+            p.addParameter('paraSD',15,@isscalar);
             p.addParameter('hrfType','flobs',@ischar);            
             p.addParameter('verbose',true,@islogical);
             
@@ -266,6 +268,7 @@ classdef mtSinai < handle
             obj.payload = p.Results.payload;
             obj.polyDeg = p.Results.polyDeg;
             obj.typicalGain = p.Results.typicalGain;
+            obj.paraSD = p.Results.paraSD;
             obj.hrfType = p.Results.hrfType;
             obj.verbose = p.Results.verbose;
             

--- a/code/models/@mtSinai/setbounds.m
+++ b/code/models/@mtSinai/setbounds.m
@@ -43,12 +43,12 @@ switch obj.hrfType
         mu = obj.mu;
         C = obj.C;
         
-        % Set bounds at +-15SDs of the norm distributions of the FLOBS
-        % parameters
-        sd15 = 15*diag(C)';
+        % Set bounds at +- n * SDs of the norm distributions of the FLOBS
+        % parameters, default n = 15
+        sdBound = obj.paraSD * diag(C)';
         
-        lb(nParams-2:nParams) = mu-sd15;	% FLOBS eigen1, 2, 3
-        ub(nParams-2:nParams) = mu+sd15;	% FLOBS eigen1, 2, 3
+        lb(nParams-2:nParams) = mu-sdBound;	% FLOBS eigen1, 2, 3
+        ub(nParams-2:nParams) = mu+sdBound;	% FLOBS eigen1, 2, 3
 
     case 'gamma'
         lb(nParams-2:nParams) = [2 6 0];	% Gamma1,2, and undershoot gain


### PR DESCRIPTION
Added 'paraSD' as an optional argument to mt Sinai model so the bounds on the HRF parameters can be changed to n * S.D.
If none is passed the default is still 15 * S.D.